### PR TITLE
Complete Background Image Endpoint

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::BackgroundsController < ApplicationController
+  def show
+    image = ImageFacade.new(params[:location]).get_image
+    serialized_image = ImageSerializer.new(image)
+    render json: serialized_image, status: 200
+  end
+end

--- a/app/facades/image_facade.rb
+++ b/app/facades/image_facade.rb
@@ -1,0 +1,13 @@
+class ImageFacade
+  attr_reader :location
+
+  def initialize(location)
+    @location = location.gsub(/,/, ' ')
+  end
+
+  def get_image
+    image_service = UnsplashService.new
+    image_info = image_service.get_image_info(location)
+    Image.new(image_info)
+  end
+end

--- a/app/models/poros/image.rb
+++ b/app/models/poros/image.rb
@@ -1,0 +1,26 @@
+class Image
+  attr_reader :id, :url, :photographer_name, :photographer_url
+
+  def initialize(info)
+    @id = rand(10000)
+    if info[:results].first
+      search_image(info)
+    else
+      default_image(info)
+    end
+  end
+
+  private
+
+  def search_image(info)
+    @url = info[:results][0][:urls][:raw]
+    @photographer_name = info[:results][0][:user][:name]
+    @photographer_url = info[:results][0][:user][:portfolio_url]
+  end
+
+  def default_image(info)
+    @url = 'https://images.unsplash.com/photo-1528872042734-8f50f9d3c59b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDU5Mn0'
+    @photographer_name = 'Agustinus Nathaniel'
+    @photographer_url = 'https://agustinusnathaniel.com'
+  end
+end

--- a/app/serializers/image_serializer.rb
+++ b/app/serializers/image_serializer.rb
@@ -1,0 +1,5 @@
+class ImageSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :url, :photographer_name, :photographer_url
+end

--- a/app/services/unsplash_service.rb
+++ b/app/services/unsplash_service.rb
@@ -1,0 +1,12 @@
+class UnsplashService
+  def get_image_info(location)
+    response = Faraday.get('https://api.unsplash.com/search/photos') do |req|
+      req.params['client_id'] = ENV['UNSPLASH_CLIENT_ID']
+      req.params['query'] = location
+      req.params['per_page'] = 1
+      req.params['orientation'] = 'landscape'
+    end
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      get  '/forecast',  to: 'forecasts#show'
-      post '/users',     to: 'users#create'
-      post '/sessions',  to: 'sessions#create'
-      post '/road_trip', to: 'road_trips#create'
+      get  '/forecast',    to: 'forecasts#show'
+      get  '/backgrounds', to: 'backgrounds#show'
+      
+      post '/users',       to: 'users#create'
+      post '/sessions',    to: 'sessions#create'
+      post '/road_trip',   to: 'road_trips#create'
     end
   end
 end

--- a/spec/requests/api/v1/background_image_spec.rb
+++ b/spec/requests/api/v1/background_image_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Background Image API Endpoint' do
+  it 'returns the URL of an image for a given location' do
+    get '/api/v1/backgrounds?location=denver,co', headers: {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+
+    expect(response).to be_successful
+
+    image_info = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    url = 'https://images.unsplash.com/photo-1521224911436-5b591bffc321?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDU5Mn0'
+    expect(image_info[:attributes][:url]).to eq(url)
+    expect(image_info[:attributes][:photographer_name]).to eq('Jeff Brown')
+
+    portfolio_url = 'http://www.jeffbrownphoto.com'
+    expect(image_info[:attributes][:photographer_url]).to eq(portfolio_url)
+  end
+
+  it 'returns a default image if no image is found' do
+    get '/api/v1/backgrounds?location=sdkljhgakfjg', headers: {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+
+    expect(response).to be_successful
+
+    image_info = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    url = 'https://images.unsplash.com/photo-1528872042734-8f50f9d3c59b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjExMDU5Mn0'
+    expect(image_info[:attributes][:url]).to eq(url)
+    expect(image_info[:attributes][:photographer_name]).to eq('Agustinus Nathaniel')
+
+    portfolio_url = 'https://agustinusnathaniel.com'
+    expect(image_info[:attributes][:photographer_url]).to eq(portfolio_url)
+  end
+end


### PR DESCRIPTION
- Add backgrounds controller that uses an image facade to create an image PORO
- Add Unsplash service to grab images based on a given location
- Image PORO defaults to a picture of clouds in the sky if the API call does not return results
- Test coverage is at 100%